### PR TITLE
Add Socratic method chatbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# socratic-chatbot-app
+# Socratic Chatbot App
+
+This project contains a simple command-line chatbot that employs the Socratic method. 
+The bot responds to user input with thoughtful questions, encouraging deeper reflection.
+
+## Usage
+
+```bash
+python socratic_chatbot.py
+```
+
+Type your message and the bot will reply as a wise mentor. Enter `exit` or `quit`
+to end the conversation.

--- a/socratic_chatbot.py
+++ b/socratic_chatbot.py
@@ -1,0 +1,53 @@
+import random
+import re
+
+
+STOPWORDS = {
+    'the', 'is', 'a', 'an', 'and', 'or', 'but', 'if', 'in', 'on', 'to',
+    'with', 'of', 'for', 'as', 'at', 'by', 'be', 'this', 'that'
+}
+
+
+def extract_keywords(text: str) -> str:
+    """Return a simplified string of key words from user input."""
+    words = re.findall(r"\b\w+\b", text.lower())
+    keywords = [w for w in words if w not in STOPWORDS]
+    if not keywords:
+        return text.strip()
+    # Use up to last three keywords to keep context short
+    return " ".join(keywords[-3:])
+
+
+def socratic_prompt(text: str) -> str:
+    """Generate a Socratic-style question with a mentor tone."""
+    key = extract_keywords(text)
+    templates = [
+        "Why do you think {key}?",
+        "What leads you to believe {key}?",
+        "How does {key} fit into the bigger picture?",
+        "What would change if {key} were different?",
+        "Can you think of an example that illustrates {key}?",
+        "What might be the consequences of {key}?",
+        "How might someone else view {key}?"
+    ]
+    template = random.choice(templates)
+    return f"Hmm. {template.format(key=key)}"
+
+
+def main() -> None:
+    print("Wise Mentor: Greetings, seeker. How may I assist you today?")
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()  # move to next line
+            user_input = "exit"
+        if user_input.lower() in {"exit", "quit"}:
+            print("Wise Mentor: Farewell. Continue your journey with curiosity.")
+            break
+        response = socratic_prompt(user_input)
+        print(f"Wise Mentor: {response}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add Python script implementing a Socratic-style chatbot that replies like a wise mentor.
- Document chatbot usage and ignore Python cache files.

## Testing
- `python socratic_chatbot.py <<'EOF'
Hello mentor
I want to learn about philosophy
quit
EOF`
- `python -m py_compile socratic_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_6898c4c98828833097d7e0a4a3dd233e